### PR TITLE
Fix Equals implementation for empty value cases

### DIFF
--- a/src/CSharpDiscriminatedUnion.Generation.Tests/EqualityFixtures/SerializableEqualityFixture.cs
+++ b/src/CSharpDiscriminatedUnion.Generation.Tests/EqualityFixtures/SerializableEqualityFixture.cs
@@ -1,0 +1,51 @@
+﻿using CSharpDiscriminatedUnion.Generation.Tests.UnionTypes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSharpDiscriminatedUnion.Generation.Tests.EqualityFixtures
+{
+    public class SerializableEqualityFixture : UnionEqualityFixture<SerializableUnion>
+    {
+        private readonly IFormatter _formatter = new BinaryFormatter();
+
+        private readonly MemoryStream _streamedDefault = new MemoryStream();
+        private readonly MemoryStream _streamedOneValue = new MemoryStream();
+
+        public SerializableEqualityFixture()
+        {
+            _formatter.Serialize(_streamedDefault, SerializableUnion.Default);
+            _formatter.Serialize(_streamedOneValue, SerializableUnion.NewOneValue("foo"));
+        }
+
+        public override IEnumerable<Func<SerializableUnion>> SameValues
+        {
+            get
+            {
+                yield return () => Deserialize(_streamedDefault);
+                yield return () => Deserialize(_streamedOneValue);
+            }
+        }
+
+        public override IEnumerable<(SerializableUnion, SerializableUnion)> DifferentValues
+        {
+            get
+            {
+                yield return (Deserialize(_streamedDefault), Deserialize(_streamedOneValue));
+            }
+        }
+
+        public override SerializableUnion AnonymousValue => SerializableUnion.Default;
+
+        private SerializableUnion Deserialize(Stream stream)
+        {
+            stream.Seek(0L, SeekOrigin.Begin);
+            return (SerializableUnion)_formatter.Deserialize(stream);
+        }
+    }
+}

--- a/src/CSharpDiscriminatedUnion.Generation.Tests/EqualityTests.cs
+++ b/src/CSharpDiscriminatedUnion.Generation.Tests/EqualityTests.cs
@@ -40,6 +40,7 @@ namespace CSharpDiscriminatedUnion.Generation.Tests
     [TestFixture(typeof(MediaStruct_CollectionArray), typeof(MediaStruct_CollectionArray_EqualityFixture))]
     [TestFixture(typeof(MediaStruct_CollectionList), typeof(MediaStruct_CollectionList_EqualityFixture), Ignore = "Not supported")]
     [TestFixture(typeof(MediaStruct_CollectionImmutableArray), typeof(MediaStruct_CollectionImmutableArray_EqualityFixture))]
+    [TestFixture(typeof(SerializableUnion), typeof(SerializableEqualityFixture))]
     public class EqualityTests<T, TFixtureData>
         where TFixtureData : UnionEqualityFixture<T>, new()
         where T : IEquatable<T>

--- a/src/CSharpDiscriminatedUnion.Generation.Tests/UnionTypes/SerializableUnion.cs
+++ b/src/CSharpDiscriminatedUnion.Generation.Tests/UnionTypes/SerializableUnion.cs
@@ -1,0 +1,29 @@
+﻿using CSharpDiscriminatedUnion.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSharpDiscriminatedUnion.Generation.Tests.UnionTypes
+{
+    [Serializable]
+    [GenerateDiscriminatedUnion]
+    public partial class SerializableUnion
+    {
+        partial class Cases
+        {
+            [Serializable]
+            partial class Default : SerializableUnion
+            {
+            }
+
+            [Serializable]
+            partial class OneValue : SerializableUnion
+            {
+                readonly string stringValue;
+            }
+        }
+    }
+}

--- a/src/CSharpDiscriminatedUnion.Generation/Generators/Class/GenerateCaseEquatableImplementation.cs
+++ b/src/CSharpDiscriminatedUnion.Generation/Generators/Class/GenerateCaseEquatableImplementation.cs
@@ -119,7 +119,7 @@ namespace CSharpDiscriminatedUnion.Generation.Generators.Class
         {
             if (@case.CaseValues.Length == 0)
             {
-                return Argument(ParenthesizedLambdaExpression(GeneratorHelpers.FalseExpression()));
+                return Argument(ParenthesizedLambdaExpression(GeneratorHelpers.TrueExpression()));
             }
             var lambdaBody =
                 @case.CaseValues.Skip(1).Aggregate(


### PR DESCRIPTION
When no field is set for a case, the lambda equality was returning False instead of True when the instance types are matching.

I also added a unit test for types used for serialization.